### PR TITLE
Slideshow content kind pr

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from le_utils.constants import licenses, content_kinds, exercises, roles
 from ricecooker.classes.files import *
 from ricecooker.classes.files import _ExerciseImageFile, _ExerciseBase64ImageFile, _ExerciseGraphieFile
-from ricecooker.classes.nodes import ChannelNode, TopicNode, VideoNode, AudioNode, DocumentNode, HTML5AppNode, ExerciseNode
+from ricecooker.classes.nodes import ChannelNode, TopicNode, VideoNode, AudioNode, DocumentNode, HTML5AppNode, ExerciseNode, SlideshowNode
 from ricecooker.classes.questions import SingleSelectQuestion, InputQuestion
 
 from ricecooker.__init__ import __version__
@@ -561,4 +561,44 @@ def exercise_graphie_replacement_str():
 @pytest.fixture
 def exercise_graphie_filename():
     return 'ea2269bb5cf487f8d883144b9c06fbc7.graphie'
+
+
+
+
+# SLIDESHOW IMAGES FIXTURES
+################################################################################
+
+@pytest.fixture
+def slideshow_files():
+    fake_files = []
+    for i in range(0,10):
+        filename = 'tests/testcontent/slide' + str(i) + '.jpg'
+        if not os.path.exists(filename):
+            with open(filename, 'w') as f:
+                f.write('jpgdatawouldgohere' + str(i))
+        fake_files.append(
+            SlideImageFile(filename, caption='slide ' + str(i))
+        )
+    return fake_files
+
+@pytest.fixture
+def slideshow_data(contentnode_base_data, slideshow_files, channel_domain_namespace, channel_node_id):
+    slideshow_data = copy.deepcopy(contentnode_base_data)
+    ids_dict = genrate_random_ids(channel_domain_namespace, channel_node_id)
+    slideshow_data.update(ids_dict)
+    slideshow_data.update({ "kind": content_kinds.SLIDESHOW })
+    # TODO setup expected extra_fields['slideshow_data']
+    return slideshow_data
+
+@pytest.fixture
+def slideshow(slideshow_files, slideshow_data, channel):
+    args_data = get_content_node_args(slideshow_data)
+    contentnode_kwargs = get_content_node_kwargs(slideshow_data)
+    del contentnode_kwargs['extra_fields']
+    slideshow = SlideshowNode(*args_data, **contentnode_kwargs)
+    for slideshow_file in slideshow_files:
+        slideshow.add_file(slideshow_file)
+    channel.add_child(slideshow)
+    slideshow_data['files'] = slideshow_files   # save it so we can compare later
+    return slideshow
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -148,3 +148,20 @@ def test_exercise_to_dict(exercise, exercise_data):
         assert key in exercise_dict, "Key {} is not found in to_dict method".format(key)
     for key, value in exercise_dict.items():
         assert value == exercise_data.get(key), "Mismatched {}: {} != {}".format(key, value, exercise_data[key])
+
+def test_slideshow_to_dict(slideshow, slideshow_data):
+    slideshow_dict = slideshow.to_dict()
+    extra_fields = json.loads(slideshow_dict['extra_fields'])
+    assert len(extra_fields['slideshow_data']) == 10, 'wrong num slides'
+    # TODO check extra_fields
+    del slideshow_data['extra_fields']
+    del slideshow_dict['extra_fields']
+    #
+    expected_files = slideshow_data.pop('files')    
+    slideshow_dict.pop('files')
+    assert slideshow.files == expected_files, "slide_images do not match"
+    for key, _ in slideshow_data.items():
+        assert key in slideshow_dict, "Key {} is not found in to_dict method".format(key)
+    for key, value in slideshow_dict.items():
+         assert value == slideshow_data.get(key), "Mismatched {}: {} != {}".format(key, value, slideshow_data[key])
+

--- a/tests/test_pdfutils.py
+++ b/tests/test_pdfutils.py
@@ -151,7 +151,7 @@ def test_get_toc_subchapters(doc1_with_toc_path, downloads_dir):
 def test_split_subchapters(doc1_with_toc_path, downloads_dir):
     with PDFParser(doc1_with_toc_path, directory=downloads_dir) as pdfparser:
         chapters = pdfparser.split_subchapters()
-        pprint(chapters)
+        # pprint(chapters)
         for ch in chapters[0:4]:
             assert 'children' not in ch, 'first four chapters have no subchapters...'
         assert _get_pdf_len(chapters[0]) == 1, 'wrong num pages in ' + str(chapters[0])

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -157,3 +157,95 @@ def test_validate_tree(tree, invalid_tree, invalid_tree_2):
     except InvalidNodeException:
         pass
 
+
+
+
+
+
+
+
+
+
+""" *********** SLIDESHOW CONTENT NODE TESTS *********** """
+
+
+def test_slideshow_node_via_files(channel):
+    slideshow_node = SlideshowNode(
+        title="The Slideshow",
+        description="Slideshow Content Demo",
+        source_id='demo',
+        author="DE Mo",
+        language='en',
+        license=get_license('CC BY', copyright_holder='Demo Holdings'),
+        files=[
+            SlideImageFile(
+                path='https://www.sales-training-lead-generation.com/wp-content/uploads/2010/12/software-demo-thingy.jpg',
+                language='en',
+                caption="Demo blocks are neat."
+            ),
+            SlideImageFile(
+                path='https://udemy-images.udemy.com/course/750x422/8075_b2b5_10.jpg',
+                language='en',
+                caption="Touch the demo to learn new things!"
+            ),
+            SlideImageFile(
+                path='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRmL1l3TQUxFFXX8zZLujUt60Kud24CgMywVi1OIoj0TrQLgmjB',
+                language='en',
+                caption="Made mostly with Python!"
+            ),
+            SlideImageFile(
+                path='http://www.quickmeme.com/img/94/94a5cc4bca4e267b876733917e556dca7b52f6b5da949c13855a605312e9aa4e.jpg',
+                language='en',
+                caption="Meow! Cat memes are a great way to spice up your demos!"
+            ),
+            SlideImageFile(
+                path='https://www.yellowfinbi.com/assets/files/2018/09/YF_O1-638x400.png',
+                language='en',
+                caption="Unlock your potential with this demo."
+            )
+        ]
+    )
+    assert slideshow_node
+    assert slideshow_node.kind == 'slideshow'
+    assert len(slideshow_node.files) == 5, 'missing files'
+    assert slideshow_node.extra_fields, 'missing extra_fields'
+    assert 'slideshow_data' in slideshow_node.extra_fields, 'missing slideshow_data key'
+    slideshow_node.process_files()
+    # slideshow_node.to_dict() not ready yet bcs needs ot be part of tree...
+    channel.add_child(slideshow_node)
+    assert channel.validate_tree()
+    assert slideshow_node.to_dict() # not ready yet bcs needs ot be part of tree...
+
+
+
+
+def test_slideshow_node_via_add_file(channel):
+    slideshow_node = SlideshowNode(
+        title="The Slideshow via add_files",
+        description="Slideshow Content Demo",
+        source_id='demo2',
+        author="DE Mo",
+        language='en',
+        license=get_license('CC BY', copyright_holder='Demo Holdings'),
+        files=[]
+    )
+    slideimg1 = SlideImageFile(
+        path='https://www.sales-training-lead-generation.com/wp-content/uploads/2010/12/software-demo-thingy.jpg',
+        language='en',
+        caption="Demo blocks are neat."
+    )
+    slideshow_node.add_file(slideimg1)
+    slideimg2 = SlideImageFile(
+        path='https://udemy-images.udemy.com/course/750x422/8075_b2b5_10.jpg',
+        language='en',
+        caption="Touch the demo to learn new things!"
+    )
+    slideshow_node.add_file(slideimg2)
+
+    # print(slideshow_node.__dict__)
+    assert slideshow_node
+    assert len(slideshow_node.files) == 2, 'missing files'
+
+    channel.add_child(slideshow_node)
+    assert channel.validate_tree()
+

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ setenv =
     PYTHONPATH = {toxinidir}
 commands =
     pip install -U pip
+    pip install -U git+https://github.com/nucleogenesis/le-utils.git@slideshow-content-type#egg=le-utils
     py.test --basetemp={envtmpdir}
 
 [testenv:flake8]


### PR DESCRIPTION
Hi @nucleogenesis 

While reviewing https://github.com/learningequality/ricecooker/pull/208 on Friday I realized it assumes files added to nodes always up front (via `files` kwarg). There is also another way to add files one-by-one after creating a node object by calling it's `add_file` method.

So I refactored the code in `__init__` to call `add_file`, then I realized that the default `__init__` already calls `add_file` for each file, (see https://github.com/learningequality/ricecooker/blob/master/ricecooker/classes/nodes.py#L33-L34 ) so in the end all we have to do special for Slideshow is put the caption-processing logic in the `add_file` method, which his what I did.

I also changed the structure of `extra_fields` to be dict-like and store slideshow data in `slideshow_data` key. Feel free to change to another key name as needed. *Note you'll have to change the Studio side to expect this same key instead of list.*

The rest of this PR is some basic fixtures and tests to help you check all things are in the right place. Note I did only rudamentary checks and left some TODOs for you to fill in once you finalize the design and data format.