### PR TITLE
Defilterization

### DIFF
--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -877,10 +877,10 @@ class SlideshowNode(ContentNode):
     def validate(self):
         from .files import SlideImageFile, ThumbnailFile
         try:
-            assert any(self.files), "Assumption Failed: Slideshow does not have any slideshow image files."
-            for file in self.files:
-                assert isinstance(file, SlideImageFile) or isinstance(file, ThumbnailFile), "Assumption Failed: Slideshow files must all be of type SlideImageFile or ThumbnailFile."
-            #
+            assert [f for f in self.files if isinstance(f, SlideImageFile)], \
+                "Assumption Failed: SlideshowNode must have at least one SlideImageFile file."
+            assert all([isinstance(f, SlideImageFile) or isinstance(f, ThumbnailFile) for f in self.files]), \
+                   "Assumption Failed: SlideshowNode files must be of type SlideImageFile or ThumbnailFile."
         except AssertionError as ae:
             raise InvalidNodeException("Invalid node ({}): {} - {}".format(ae.args[0], self.title, self.__dict__))
         super(SlideshowNode, self).validate()

--- a/ricecooker/classes/nodes.py
+++ b/ricecooker/classes/nodes.py
@@ -605,7 +605,7 @@ class AudioNode(ContentNode):
             assert self.kind == content_kinds.AUDIO, "Assumption Failed: Node should be audio"
             assert self.questions == [], "Assumption Failed: Audio should not have questions"
             assert len(self.files) > 0, "Assumption Failed: Audio should have at least one file"
-            assert any(filter(lambda f: isinstance(f, AudioFile), self.files)), "Assumption Failed: Audio should have at least one audio file"
+            assert [f for f in self.files if isinstance(f, AudioFile)], "Assumption Failed: Audio should have at least one audio file"
             return super(AudioNode, self).validate()
         except AssertionError as ae:
             raise InvalidNodeException("Invalid node ({}): {} - {}".format(ae.args[0], self.title, self.__dict__))
@@ -642,7 +642,8 @@ class DocumentNode(ContentNode):
             assert self.kind == content_kinds.DOCUMENT, "Assumption Failed: Node should be a document"
             assert self.questions == [], "Assumption Failed: Document should not have questions"
             assert len(self.files) > 0, "Assumption Failed: Document should have at least one file"
-            assert any(filter(lambda f: isinstance(f, DocumentFile) or isinstance(f, EPubFile), self.files)), "Assumption Failed: Document should have at least one document file"
+            assert [f for f in self.files if isinstance(f, DocumentFile) or isinstance(f, EPubFile)], \
+                "Assumption Failed: Document should have at least one document file"
             return super(DocumentNode, self).validate()
         except AssertionError as ae:
             raise InvalidNodeException("Invalid node ({}): {} - {}".format(ae.args[0], self.title, self.__dict__))
@@ -679,7 +680,7 @@ class HTML5AppNode(ContentNode):
         try:
             assert self.kind == content_kinds.HTML5, "Assumption Failed: Node should be an HTML5 app"
             assert self.questions == [], "Assumption Failed: HTML should not have questions"
-            assert any(filter(lambda f: isinstance(f, HTMLZipFile), self.files)), "Assumption Failed: HTML should have at least one html file"
+            assert [f for f in self.files if isinstance(f, HTMLZipFile)], "Assumption Failed: HTML should have at least one html file"
             return super(HTML5AppNode, self).validate()
 
         except AssertionError as ae:
@@ -787,8 +788,9 @@ class ExerciseNode(ContentNode):
 
             # Check if questions are correct
             assert any(self.questions), "Assumption Failed: Exercise does not have a question"
-            assert all(filter(lambda q: q.validate(), self.questions)), "Assumption Failed: Exercise has invalid question"
-            assert self.extra_fields['mastery_model'] in MASTERY_MODELS, "Assumption Failed: Unrecognized mastery model {}".format(self.extra_fields['mastery_model'])
+            assert all([q.validate() for q in self.questions]), "Assumption Failed: Exercise has invalid question"
+            assert self.extra_fields['mastery_model'] in MASTERY_MODELS, \
+                "Assumption Failed: Unrecognized mastery model {}".format(self.extra_fields['mastery_model'])
             return super(ExerciseNode, self).validate()
         except AssertionError as ae:
             raise InvalidNodeException("Invalid node ({}): {} - {}".format(ae.args[0], self.title, self.__dict__))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -154,8 +154,7 @@ def test_slideshow_to_dict(slideshow, slideshow_data):
     extra_fields = json.loads(slideshow_dict['extra_fields'])
     assert len(extra_fields['slideshow_data']) == 10, 'wrong num slides'
     expected_field_keys = { 'caption', 'descriptive_text', 'checksum', 'sort_order', 'extension'}
-    for slide_data in extra_fields['slideshow_data']:
-        assert set(slide_data.keys()) == expected_field_keys, 'extra_fields is missing expected fields'
+    assert all([set(sd.keys()) == expected_field_keys for sd in extra_fields['slideshow_data']]), 'extra_fields is missing expected fields'
     del slideshow_data['extra_fields']
     del slideshow_dict['extra_fields']
     #

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -120,14 +120,14 @@ def test_ids(tree, channel_node_id, channel_content_id, topic_content_id, topic_
     assert document.get_node_id() == document_node_id, "Document node id should be {}".format(document_node_id)
 
 def test_add_file(document, document_file):
-    test_files = list(filter(lambda f: isinstance(f, DocumentFile), document.files))
+    test_files = [f for f in document.files if isinstance(f, DocumentFile)]
     assert any(test_files), "Document must have at least one file"
     assert test_files[0] == document_file, "Document file was not added correctly"
 
 def test_thumbnail(topic, document, thumbnail_path):
     assert document.has_thumbnail(), "Document must have a thumbnail"
     assert not topic.has_thumbnail(), "Topic must not have a thumbnail"
-    assert any(filter(lambda f: f.path == thumbnail_path, document.files)), "Document is missing a thumbnail with path {}".format(thumbnail_path)
+    assert [f for f in document.files if f.path == thumbnail_path], "Document is missing a thumbnail with path {}".format(thumbnail_path)
 
 def test_count(tree):
     assert tree.count() == 2, "Channel should have 2 descendants"


### PR DESCRIPTION
patch on top of https://github.com/learningequality/ricecooker/pull/208 to remove the use of any(filter and any(filter code pattern in favor of more pythonic list comprehension